### PR TITLE
chore: simplify go code

### DIFF
--- a/guide/getting-started-with-testcontainers-for-go/index.adoc
+++ b/guide/getting-started-with-testcontainers-for-go/index.adoc
@@ -173,7 +173,7 @@ then we have implemented separate tests for CreateCustomer and GetCustomerByEmai
 
 [TIP]
 For the purpose of this guide, we are not resetting the data in the database.
-But it is a good practice to rest the database in a known state before running any test.
+But it is a good practice to reset the database in a known state before running any test.
 
 == Run tests
 

--- a/guide/getting-started-with-testcontainers-for-go/index.adoc
+++ b/guide/getting-started-with-testcontainers-for-go/index.adoc
@@ -159,8 +159,7 @@ and initialize `customerRepository` as follows:
 include::{codebase}/main_test.go[]
 ----
 
-We have created a `PostgresContainer` struct as a wrapper to hold the actual postgres container,
-a callback function to remove the container and `ConnectionString` obtained from the started container.
+We have created a `PostgresContainer` struct as a wrapper to hold the actual postgres container and `ConnectionString` obtained from the started container.
 
 Now create `customer_repository_test.go` file and write multiple tests which will be using the same container as follows:
 


### PR DESCRIPTION
## What is this PR doing?
It removes the CLoseFn function, as we already have a Terminate method in the container

At the same time, it simplifies the struct holding the container, embedding the postgres' container type from the module into the struct used in tests.

## Why is it important?
Use more idiomatic approach
